### PR TITLE
separate access_token from user

### DIFF
--- a/src/apps/AdminApp/AdminRoot.js
+++ b/src/apps/AdminApp/AdminRoot.js
@@ -67,7 +67,7 @@ class AdminRoot extends Component {
              nextState.usersTabs.length !== usersTabs.length;
     }
 
-    checkPermission = (user) => {
+    checkPermission = (user, access_token) => {
         const roles = new Set(user.roles || []);
 
         let role = null;
@@ -83,7 +83,7 @@ class AdminRoot extends Component {
             console.log("[Admin] checkPermission role is", role);
             delete user.roles;
             user.role = role;
-            this.initApp(user);
+            this.initApp(user, access_token);
         } else {
             alert("Access denied!");
             client.signoutRedirect();
@@ -111,10 +111,10 @@ class AdminRoot extends Component {
 
     withAudio = () => (this.isAllowed("admin"));
 
-    initApp = (user) => {
+    initApp = (user, access_token) => {
         this.setState({user});
 
-        api.setAccessToken(user.access_token);
+        api.setAccessToken(access_token);
         client.events.addUserLoaded((user) => api.setAccessToken(user.access_token));
         client.events.addUserUnloaded(() => api.setAccessToken(null));
 

--- a/src/apps/GalaxyApp.js
+++ b/src/apps/GalaxyApp.js
@@ -20,13 +20,11 @@ class GalaxyApp extends Component {
         roles: [],
     };
 
-    componentDidMount() {
+    checkPermission = (user, access_token) => {
+      api.setAccessToken(access_token);
       client.events.addUserLoaded((user) => api.setAccessToken(user.access_token));
       client.events.addUserUnloaded(() => api.setAccessToken(null));
-    }
 
-    checkPermission = (user) => {
-      api.setAccessToken(user.access_token);
       if (user.role === 'ghost') {
         getUserRemote((user) => this.checkPermission_(user));
       } else {

--- a/src/apps/MobileApp/MobileClient.js
+++ b/src/apps/MobileApp/MobileClient.js
@@ -85,7 +85,7 @@ class MobileClient extends Component {
       }
     };
 
-    checkPermission = (user) => {
+    checkPermission = (user, access_token) => {
         const {t} = this.props;
         let gxy_user = user.roles.filter(role => role === 'gxy_user').length > 0;
         let pending_approval = user.roles.filter(role => role === 'pending_approval').length > 0;
@@ -95,7 +95,7 @@ class MobileClient extends Component {
         } else if (gxy_user) {
             delete user.roles;
             user.role = "user";
-            this.initApp(user);
+            this.initApp(user, access_token);
         } else {
             alert("Access denied!");
             client.signoutRedirect();
@@ -109,7 +109,7 @@ class MobileClient extends Component {
         }
     };
 
-    initApp = (user) => {
+    initApp = (user, access_token) => {
         const { t } = this.props;
         localStorage.setItem('question', false);
         localStorage.setItem('sound_test', false);
@@ -128,7 +128,7 @@ class MobileClient extends Component {
                 }
                 this.setState({ geoinfo: !!data, user });
 
-                api.setAccessToken(user.access_token);
+                api.setAccessToken(access_token);
                 client.events.addUserLoaded((user) => api.setAccessToken(user.access_token));
                 client.events.addUserUnloaded(() => api.setAccessToken(null));
 

--- a/src/apps/ShidurApp/ShidurApp.js
+++ b/src/apps/ShidurApp/ShidurApp.js
@@ -35,23 +35,23 @@ class ShidurApp extends Component {
         Object.values(this.state.gateways).forEach(x => x.destroy());
     };
 
-    checkPermission = (user) => {
+    checkPermission = (user, access_token) => {
         const allowed = user.roles.filter(role => role === 'gxy_shidur').length > 0;
         if (allowed) {
             delete user.roles;
             user.role = "shidur";
             user.session = 0;
-            this.initApp(user);
+            this.initApp(user, access_token);
         } else {
             alert("Access denied!");
             client.signoutRedirect();
         }
     };
 
-    initApp = (user) => {
+    initApp = (user, access_token) => {
         this.setState({user});
 
-        api.setAccessToken(user.access_token);
+        api.setAccessToken(access_token);
         client.events.addUserLoaded((user) => api.setAccessToken(user.access_token));
         client.events.addUserUnloaded(() => api.setAccessToken(null));
 

--- a/src/apps/SndmanApp/SndmanApp.js
+++ b/src/apps/SndmanApp/SndmanApp.js
@@ -22,23 +22,23 @@ class SndmanApp extends Component {
         Object.values(this.state.gateways).forEach(x => x.destroy());
     };
 
-    checkPermission = (user) => {
+    checkPermission = (user, access_token) => {
         const allowed = user.roles.filter(role => role === 'gxy_sndman').length > 0;
         if (allowed) {
             delete user.roles;
             user.role = "sndman";
             user.session = 0;
-            this.initApp(user);
+            this.initApp(user, access_token);
         } else {
             alert("Access denied!");
             client.signoutRedirect();
         }
     };
 
-    initApp = (user) => {
+    initApp = (user, access_token) => {
         this.setState({user});
 
-        api.setAccessToken(user.access_token);
+        api.setAccessToken(access_token);
         client.events.addUserLoaded((user) => api.setAccessToken(user.access_token));
         client.events.addUserUnloaded(() => api.setAccessToken(null));
 

--- a/src/apps/StreamApp/GalaxyStream.js
+++ b/src/apps/StreamApp/GalaxyStream.js
@@ -29,14 +29,14 @@ class GalaxyStream extends Component {
         appInitError: null,
     };
 
-    checkPermission = (user) => {
+    checkPermission = (user, access_token) => {
         let gxy_group = user.roles.filter(role => role === 'gxy_group').length > 0;
         let gxy_user = user.roles.filter(role => role === 'gxy_user').length > 0;
         //let gxy_public = user.roles.filter(role => role === 'bb_user').length > 0;
         if (gxy_user) {
             delete user.roles;
             user.role = gxy_group ? "group" : gxy_user ? "user" : "public";
-            this.initApp(user);
+            this.initApp(user, access_token);
         } else {
             alert("Access denied!");
             client.signoutRedirect();
@@ -47,7 +47,7 @@ class GalaxyStream extends Component {
         this.state.janus.destroy();
     };
 
-    initApp = (user) => {
+    initApp = (user, access_token) => {
         fetch(`${GEO_IP_INFO}`)
             .then((response) => {
                 if (response.ok) {
@@ -56,7 +56,7 @@ class GalaxyStream extends Component {
                             localStorage.setItem("gxy_extip", info.ip);
                             this.setState({user: {...info,...user}});
 
-                            api.setAccessToken(user.access_token);
+                            api.setAccessToken(access_token);
                             client.events.addUserLoaded((user) => api.setAccessToken(user.access_token));
                             client.events.addUserUnloaded(() => api.setAccessToken(null));
 

--- a/src/apps/VirtualApp/VirtualClient.js
+++ b/src/apps/VirtualApp/VirtualClient.js
@@ -126,10 +126,13 @@ class VirtualClient extends Component {
     this.state.virtualStreamingJanus.destroy();
   }
 
-  checkPermission = (user) => {
+  checkPermission = (user, access_token) => {
+    api.setAccessToken(access_token);
+    client.events.addUserLoaded((user) => api.setAccessToken(user.access_token));
+    client.events.addUserUnloaded(() => api.setAccessToken(null));
+
     // If user is ghost, after login check if attributes were updated.
     if (user.role === 'ghost' || (user.pending && user.pending.length)) {
-      api.setAccessToken(user.access_token);
       getUserRemote((user) => this.checkPermissions_(user, true));
     } else {
       this.checkPermissions_(user, true);
@@ -171,10 +174,6 @@ class VirtualClient extends Component {
       this.setState({ geoinfo: !!data, user });
 
       if (firstTime) {
-        api.setAccessToken(user.access_token);
-        client.events.addUserLoaded((user) => api.setAccessToken(user.access_token));
-        client.events.addUserUnloaded(() => api.setAccessToken(null));
-
         api.fetchConfig()
             .then(data => GxyJanus.setGlobalConfig(data))
             .then(() => (api.fetchAvailableRooms({with_num_users: true})))

--- a/src/components/LoginPage.js
+++ b/src/components/LoginPage.js
@@ -33,11 +33,11 @@ class LoginPage extends Component {
     };
 
     appLogin = () => {
-        getUser(user => {
+        getUser(({user, access_token}) => {
             if(user) {
                 client.querySessionStatus().then(() => {
                     this.setState({loading: false});
-                    this.props.checkPermission(user);
+                    this.props.checkPermission(user, access_token);
                 }).catch((error) => {
                     console.log("querySessionStatus: ", error);
                     reportToSentry("querySessionStatus: " + error,{source: "login"}, user, "warning");
@@ -61,8 +61,8 @@ class LoginPage extends Component {
 
     userLogin = () => {
         this.setState({disabled: true, loading: true});
-        getUser(cb => {
-            if(!cb) client.signinRedirect({state: window.location.href});
+        getUser(({user}) => {
+            if(!user) client.signinRedirect({state: window.location.href});
         });
     };
 

--- a/src/components/UserManager.js
+++ b/src/components/UserManager.js
@@ -50,7 +50,7 @@ export const pendingApproval = (user) => user && !!user.roles.find(role => role 
 
 export const buildUserObject = (oidcUser) => {
   if (!oidcUser) {
-    return oidcUser;
+    return {user: oidcUser};
   }
   const at = KJUR.jws.JWS.parse(oidcUser.access_token);
   const {
@@ -68,7 +68,6 @@ export const buildUserObject = (oidcUser) => {
     title,
   } = oidcUser.profile;
   const user = {
-    access_token: oidcUser.access_token,
     email,
     group,
     id: sub,
@@ -82,8 +81,7 @@ export const buildUserObject = (oidcUser) => {
   };
   user.role = pendingApproval(user) ? 'ghost' : 'user';
   user_mgr = user;
-  //console.log('USER getUser', oidcUser, at, user);
-  return user;
+  return {user, access_token: oidcUser.access_token};
 }
 
 // Runs cb on local user info.
@@ -100,7 +98,7 @@ export const getUser = (cb) => {
 export const getUserRemote = (cb) => {
   // Due to difference in local and remote user structure we get local user info,
   // then remote user info and merge only few required fields.
-  getUser((user) => {
+  getUser(({user}) => {
     api.fetchUserInfo().then((remoteUser) => {
       //console.log('USER getUserRemote', remoteUser);
       const updatedUser = Object.assign({}, user);  // Shallow copy.

--- a/src/shared/Api.js
+++ b/src/shared/Api.js
@@ -114,7 +114,6 @@ class Api {
     }
 
     setAccessToken = (token) => {
-        //console.log('setAccessToken', token);
         this.accessToken = token;
     }
 


### PR DESCRIPTION
This is a fix to a serious security problem and must be merged ASAP.

User object is serialized completely and sent over the wire unencrypted (chat). Although wrong by it self, we're not going to change it now.

Talking to @bbfsdev we've decided not to put sensitive data on the user object in the first place. For future cases.