### PR TITLE
Fix race condition causing lost video streams for late-joining partic…

### DIFF
--- a/src/apps/VirtualApp/VirtualMqttClient.js
+++ b/src/apps/VirtualApp/VirtualMqttClient.js
@@ -154,6 +154,7 @@ class VirtualMqttClient extends Component {
       showCountryDialog: false,
     };
 
+    this.pendingStreams = {};
     this.hideBarsTimer = null;
     this.handleAppFullScreenChange = this.handleAppFullScreenChange.bind(this);
     this.handleUserActivityForBars = this.handleUserActivityForBars.bind(this);
@@ -197,7 +198,34 @@ class VirtualMqttClient extends Component {
         this.setState({connectionStatus});
       });
     }
+
+    this.attachPendingStreams();
   }
+
+  attachPendingStreams = () => {
+    for (const feed of Object.keys(this.pendingStreams)) {
+      const pending = this.pendingStreams[feed];
+      if (pending.video) {
+        const ref = this.refs["remoteVideo" + feed];
+        if (ref) {
+          log.info("[client] Attaching pending video stream for feed " + feed);
+          ref.srcObject = pending.video;
+          delete pending.video;
+        }
+      }
+      if (pending.audio) {
+        const ref = this.refs["remoteAudio" + feed];
+        if (ref) {
+          log.info("[client] Attaching pending audio stream for feed " + feed);
+          ref.srcObject = pending.audio;
+          delete pending.audio;
+        }
+      }
+      if (!pending.video && !pending.audio) {
+        delete this.pendingStreams[feed];
+      }
+    }
+  };
 
   handleAppFullScreenChange() {
     const appFullScreen = isFullScreen();
@@ -697,6 +725,8 @@ class VirtualMqttClient extends Component {
 
     if (janus) janus.destroy();
 
+    this.pendingStreams = {};
+
     this.setState({
       muted: false,
       question: false,
@@ -834,11 +864,23 @@ class VirtualMqttClient extends Component {
       if (track.kind === "audio") {
         log.debug("[client] Created remote audio stream:", stream);
         let remoteaudio = this.refs["remoteAudio" + feed];
-        if (remoteaudio) remoteaudio.srcObject = stream;
+        if (remoteaudio) {
+          remoteaudio.srcObject = stream;
+        } else {
+          log.warn("[client] Audio ref not ready for feed " + feed + ", storing for later");
+          if (!this.pendingStreams[feed]) this.pendingStreams[feed] = {};
+          this.pendingStreams[feed].audio = stream;
+        }
       } else if (track.kind === "video") {
         log.debug("[client] Created remote video stream:", stream);
         const remotevideo = this.refs["remoteVideo" + feed];
-        if (remotevideo) remotevideo.srcObject = stream;
+        if (remotevideo) {
+          remotevideo.srcObject = stream;
+        } else {
+          log.warn("[client] Video ref not ready for feed " + feed + ", storing for later");
+          if (!this.pendingStreams[feed]) this.pendingStreams[feed] = {};
+          this.pendingStreams[feed].video = stream;
+        }
       }
     }
   };


### PR DESCRIPTION
this fixes grey window for friends with camera on

onRemoteTrack silently dropped streams when the video/audio ref wasn't rendered yet. With React 18 automatic batching, setState({feeds}) in makeSubscription is deferred, so subscribeTo fires before the new feed's <video> element exists. When Janus responds fast, ontrack fires on a null ref and the stream is lost permanently.

Store streams that arrive before their refs exist in a pendingStreams map and attach them in componentDidUpdate once React has rendered the elements.

fix covers all these cases. The pendingStreams mechanism works regardless of when or why the track arrives before the ref is ready:

- Late publisher announcement after your join -- covered
- Mid-session reconfigure event -- covered
- Simultaneous joins -- covered
- Any future ontrack that fires before React renders -- covered

The fix sits at the exact bottleneck point -- onRemoteTrack stores what it can't attach, and componentDidUpdate attaches it once React renders the element. It doesn't matter what triggered the race.

Made-with: Cursor