### PR TITLE
Enhance VirtualMqttClient to manage pending streams and subscriptions…

### DIFF
--- a/src/apps/VirtualApp/VirtualMqttClient.js
+++ b/src/apps/VirtualApp/VirtualMqttClient.js
@@ -848,7 +848,10 @@ class VirtualMqttClient extends Component {
       if (track.kind === "audio") {
         log.debug("[client] Created remote audio stream:", stream);
         let remoteaudio = this.refs["remoteAudio" + feed];
-        if (remoteaudio) remoteaudio.srcObject = stream;
+        if (remoteaudio) {
+          remoteaudio.srcObject = stream;
+          remoteaudio.play().catch((e) => log.warn("[client] Audio play() failed for feed " + feed + ":", e.message));
+        }
       } else if (track.kind === "video") {
         log.debug("[client] Created remote video stream:", stream);
         this.pendingStreams.set(feed, stream);
@@ -864,6 +867,7 @@ class VirtualMqttClient extends Component {
     const remotevideo = this.refs["remoteVideo" + feed];
     if (remotevideo) {
       remotevideo.srcObject = stream;
+      remotevideo.play().catch((e) => log.warn("[client] Video play() failed for feed " + feed + ":", e.message));
       this.pendingStreams.delete(feed);
       if (attempt > 0) {
         log.info("[client] Attached pending video stream for feed " + feed + " on attempt " + attempt);

--- a/src/apps/VirtualApp/VirtualMqttClient.js
+++ b/src/apps/VirtualApp/VirtualMqttClient.js
@@ -155,6 +155,8 @@ class VirtualMqttClient extends Component {
     };
 
     this.hideBarsTimer = null;
+    this.pendingStreams = new Map();
+    this.pendingSubscriptions = [];
     this.handleAppFullScreenChange = this.handleAppFullScreenChange.bind(this);
     this.handleUserActivityForBars = this.handleUserActivityForBars.bind(this);
   }
@@ -697,6 +699,9 @@ class VirtualMqttClient extends Component {
 
     if (janus) janus.destroy();
 
+    this.pendingStreams.clear();
+    this.pendingSubscriptions = [];
+
     this.setState({
       muted: false,
       question: false,
@@ -788,9 +793,8 @@ class VirtualMqttClient extends Component {
     }
 
     if (this.state.creatingFeed) {
-      setTimeout(() => {
-        this.subscribeTo(subscription);
-      }, 500);
+      log.info("[client] Queuing subscription while subscriber is being created:", subscription);
+      this.pendingSubscriptions.push(...subscription);
       return;
     }
 
@@ -801,7 +805,13 @@ class VirtualMqttClient extends Component {
 
       this.onUpdateStreams(data.streams);
 
-      this.setState({remoteFeed: true, creatingFeed: false});
+      this.setState({remoteFeed: true, creatingFeed: false}, () => {
+        if (this.pendingSubscriptions.length > 0) {
+          const queued = this.pendingSubscriptions.splice(0);
+          log.info("[client] Flushing " + queued.length + " queued subscriptions");
+          this.state.subscriber.sub(queued);
+        }
+      });
     });
   };
 
@@ -827,6 +837,10 @@ class VirtualMqttClient extends Component {
   };
 
   onRemoteTrack = (track, stream, on) => {
+    if (!stream) {
+      log.warn("[client] onRemoteTrack called with no stream, track:", track.kind, track.id);
+      return;
+    }
     let mid = track.id;
     let feed = stream.id;
     log.info("[client] >> This track is coming from feed " + feed + ":", mid, track);
@@ -837,9 +851,32 @@ class VirtualMqttClient extends Component {
         if (remoteaudio) remoteaudio.srcObject = stream;
       } else if (track.kind === "video") {
         log.debug("[client] Created remote video stream:", stream);
-        const remotevideo = this.refs["remoteVideo" + feed];
-        if (remotevideo) remotevideo.srcObject = stream;
+        this.pendingStreams.set(feed, stream);
+        this.attachPendingStream(feed);
       }
+    }
+  };
+
+  attachPendingStream = (feed, attempt = 0) => {
+    const stream = this.pendingStreams.get(feed);
+    if (!stream) return;
+
+    const remotevideo = this.refs["remoteVideo" + feed];
+    if (remotevideo) {
+      remotevideo.srcObject = stream;
+      this.pendingStreams.delete(feed);
+      if (attempt > 0) {
+        log.info("[client] Attached pending video stream for feed " + feed + " on attempt " + attempt);
+      }
+      return;
+    }
+
+    if (attempt < 10) {
+      const delay = attempt < 3 ? 50 : 200;
+      setTimeout(() => this.attachPendingStream(feed, attempt + 1), delay);
+    } else {
+      log.warn("[client] Failed to attach video stream for feed " + feed + " after " + attempt + " attempts, ref not found");
+      this.pendingStreams.delete(feed);
     }
   };
 
@@ -871,6 +908,7 @@ class VirtualMqttClient extends Component {
       this.state.subscriber.unsub(streams);
     }
     if (!onlyVideo) {
+      idsSet.forEach((id) => this.pendingStreams.delete(id));
       this.setState({feeds: feeds.filter((feed) => !idsSet.has(feed.id))});
     }
   };

--- a/src/lib/subscriber-plugin.js
+++ b/src/lib/subscriber-plugin.js
@@ -20,6 +20,7 @@ export class SubscriberPlugin extends EventEmitter {
     this.pc = new RTCPeerConnection({
       iceServers: list
     })
+    this.jsepQueue = Promise.resolve()
   }
 
   getPluginName () {
@@ -135,19 +136,23 @@ export class SubscriberPlugin extends EventEmitter {
   }
 
   handleJsep(jsep) {
-    this.pc.setRemoteDescription(new RTCSessionDescription(jsep)).then(() => {
+    this.jsepQueue = this.jsepQueue.then(() => this.processJsep(jsep)).catch(error => {
+      log.error('[subscriber] JSEP queue error:', error)
+      captureException(error, { context: 'SubscriberPlugin.handleJsep', jsep });
+    })
+  }
+
+  processJsep(jsep) {
+    return this.pc.setRemoteDescription(new RTCSessionDescription(jsep)).then(() => {
       return this.pc.createAnswer()
     }).then(answer => {
       log.debug('[subscriber] Answer created', answer)
-      this.pc.setLocalDescription(answer).then(data => {
-        log.debug('[subscriber] setLocalDescription', data)
-      }).catch(error => {
-        log.error(error, answer)
-        captureException(error, { context: 'SubscriberPlugin.handleJsep.setLocalDescription', answer });
+      return this.pc.setLocalDescription(answer).then(() => {
+        log.debug('[subscriber] setLocalDescription done')
+        this.start(answer)
       })
-      this.start(answer)
     }).catch(error => {
-      captureException(error, { context: 'SubscriberPlugin.handleJsep', jsep });
+      captureException(error, { context: 'SubscriberPlugin.processJsep', jsep });
       throw error;
     })
   }
@@ -215,6 +220,19 @@ export class SubscriberPlugin extends EventEmitter {
       this.pc.ontrack = (e) => {
         try {
           log.debug("[subscriber] Got track: ", e)
+
+          if (!e.streams || e.streams.length === 0) {
+            log.warn("[subscriber] Track received without associated stream (missing MSID?), kind:", e.track.kind,
+              "mid:", e.transceiver?.mid);
+            captureException(new Error('Track received without stream'), {
+              context: 'SubscriberPlugin.initPcEvents.ontrack',
+              trackKind: e.track.kind,
+              trackId: e.track.id,
+              transceiverMid: e.transceiver?.mid
+            });
+            return;
+          }
+
           this.onTrack(e.track, e.streams[0], true)
 
           e.track.onmute = (ev) => {


### PR DESCRIPTION
### Описание PR

  **1. Основной фикс**: сериализация SDP-переговоров (subscriber-plugin.js → handleJsep, новый processJsep)

  Когда несколько пользователей заходят в комнату почти одновременно, handleJsep вызывался повторно до завершения предыдущего цикла setRemoteDescription → createAnswer → setLocalDescription. Второй вызов падал
  молча — видео этого пользователя терялось навсегда. Исправлено через очередь промисов (jsepQueue) — каждый JSEP ждёт завершения предыдущего. Также исправлен порядок: start(answer) теперь вызывается после
  завершения setLocalDescription, а не параллельно.

  **2. Очередь подписок вместо setTimeout** (VirtualMqttClient.js → subscribeTo)

  Подписки, приходящие во время создания subscriber'а (creatingFeed === true), теперь копятся в массиве pendingSubscriptions и отправляются одним вызовом sub() после завершения join(). Раньше каждая подписка
  перезапускалась через setTimeout(500), что могло терять подписки и вызывать множественные SDP-переговоры.

  **3. Повторные попытки привязки видео к DOM** (VirtualMqttClient.js → onRemoteTrack, новый attachPendingStream)

  Если React ещё не отрендерил <video> элемент когда приходит ontrack — поток сохраняется в pendingStreams Map и привязывается при следующей попытке (до 10 раз, ~1.5 сек). Раньше this.refs["remoteVideo" + feed]
  молча возвращал null, и поток терялся без ошибки.

  **4. Защита от пустого e.streams в ontrack** (subscriber-plugin.js → initPcEvents)

  Если трек приходит без привязанного MediaStream (отсутствует MSID в SDP) — логируем warning и отправляем в Sentry с данными трека (trackKind, trackId, transceiverMid) вместо молчаливого TypeError на
  e.streams[0].id.