### PR TITLE
VirtualApp: fix translator ducking during Talk/Q&A and boost its volume

### DIFF
--- a/src/lib/streaming-plugin.js
+++ b/src/lib/streaming-plugin.js
@@ -128,10 +128,17 @@ export class StreamingPlugin extends EventEmitter {
     } catch (_) { return; }
     if (!transceiver || !transceiver.receiver) return;
     transceiver.receiver.getStats().then(stats => {
+      let inboundLevel = null;
       stats.forEach(res => {
-        if(!res || res.kind !== "audio") return;
-        result(res.audioLevel ? res.audioLevel : 0);
+        if (!res || res.kind !== "audio") return;
+        // Only "inbound-rtp" reliably carries a live audioLevel; other audio-kind
+        // stat types (e.g. remote-inbound-rtp) can report undefined/0 and, if
+        // iterated after the real one, would silently clobber a correct reading.
+        if (res.type === "inbound-rtp") {
+          inboundLevel = res.audioLevel;
+        }
       });
+      result(inboundLevel ? inboundLevel : 0);
     }).catch(() => { /* getStats not available / track gone */ });
   }
 

--- a/src/shared/streaming-utils.js
+++ b/src/shared/streaming-utils.js
@@ -7,6 +7,13 @@ import {getVideosFromLocalstorage} from "./tools";
 import api from "./Api";
 import mqtt from "./mqtt";
 
+// Translator stream is mixed at a much lower source level than the main audio,
+// so we boost it in the Web Audio graph (HTMLMediaElement.volume can't go above 1.0/100%).
+const TRL_GAIN_DB = 10;
+const dbToGain = (db) => Math.pow(10, db / 20);
+// Low-cut before the gain/limiter so rumble/hum isn't amplified or tripping the limiter.
+const TRL_LOWCUT_HZ = 130;
+
 class JanusStream {
   constructor() {
     this.janus = null;
@@ -24,6 +31,15 @@ class JanusStream {
     // Streaing plugin for trlAudio
     this.trlAudioJanusStream = null;
     this.trlAudioMediaStream = null;
+    // Separately gain-boosted copy of trlAudioMediaStream's track, played
+    // through trlBoostElement (see constructor comment above).
+    this.trlBoostMediaStream = null;
+    this.trlGainContext = null;
+    this.trlGainNode = null;
+    // Analyser tapped into the boost graph - lets ducerMixaudio read the
+    // actual played signal's level directly instead of via getStats().
+    this.trlAnalyser = null;
+    this.trlAnalyserBuffer = null;
 
     this.videos = getVideosFromLocalstorage()
     this.audios = Number(localStorage.getItem("vrt_lang")) || 2;
@@ -43,11 +59,22 @@ class JanusStream {
     this.audioElement.muted = false;
     //this.audioElement.playinline = true;
     this.audioElement.volume = 0.6; // Default volume.
+    // trlAudioElement is a silent decoy: it keeps the raw WebRTC track flowing
+    // into an actively-rendering sink so getStats() on it stays live. It is
+    // NEVER unmuted - createMediaElementSource on a WebRTC-sourced element
+    // doesn't reliably redirect its output in Chrome, so gain-boosting it
+    // directly doesn't work audibly. trlBoostElement below is what's actually
+    // audible - it plays a separately gain-boosted copy of the same track.
     this.trlAudioElement = new Audio();
     this.trlAudioElement.autoplay = true;
     this.trlAudioElement.controls = false;
     this.trlAudioElement.muted = true;
     this.trlAudioElement.playinline = true;
+    this.trlBoostElement = new Audio();
+    this.trlBoostElement.autoplay = true;
+    this.trlBoostElement.controls = false;
+    this.trlBoostElement.muted = true;
+    this.trlBoostElement.playinline = true;
 
     this.showOn = null;
   }
@@ -191,6 +218,8 @@ class JanusStream {
         this.audioMediaStream = null;
         this.trlAudioJanusStream = null;
         this.trlAudioMediaStream = null;
+        this.trlBoostMediaStream = null;
+        this._closeTrlGainContext();
         this.videoQuadStream = null;
         if (this.reconnectAttempts >= 30) {
           log.error("[shidur] broadcast reconnect exhausted after 30 attempts");
@@ -278,6 +307,8 @@ class JanusStream {
       this.trlAudioJanusStream.watch(streamId).then((stream) => {
         this.trlAudioMediaStream = stream;
         this.attachTrlAudioStream_(this.trlAudioElement, /* reattach= */ false);
+        this.trlBoostMediaStream = this._boostTrlGain(stream);
+        this.attachTrlBoostStream_(this.trlBoostElement, /* reattach= */ false);
         this._markRecovered("translation");
       }).catch((err) => log.debug("[shidur] translation watch failed:", err && err.message));
     }).catch((err) => log.debug("[shidur] translation attach failed:", err && err.message));
@@ -311,6 +342,7 @@ class JanusStream {
       clearInterval(this.talking);
       this.talking = null;
     }
+    this._closeTrlGainContext();
     if (this.janus) {
       if (this.videoElement) {
         this.videoElement.srcObject = null;
@@ -321,6 +353,9 @@ class JanusStream {
       if (this.trlAudioElement) {
         this.trlAudioElement.srcObject = null;
       }
+      if (this.trlBoostElement) {
+        this.trlBoostElement.srcObject = null;
+      }
 
       this.videoJanusStream = null;
       this.videoMediaStream = null;
@@ -330,6 +365,7 @@ class JanusStream {
 
       this.trlAudioJanusStream = null;
       this.trlAudioMediaStream = null;
+      this.trlBoostMediaStream = null;
     }
   }
 
@@ -367,6 +403,94 @@ class JanusStream {
     }
   };
 
+  // Builds a gain-boosted copy of the raw translation stream, played through
+  // trlBoostElement (see constructor comment). This taps the raw stream
+  // directly rather than trlAudioElement's output - createMediaElementSource
+  // on a WebRTC-sourced element doesn't reliably redirect its audio in
+  // Chrome, so that route produced no audible boost. Tapping the raw stream
+  // here does work audibly, but stops the tapped track's own getStats()
+  // energy from updating - which is exactly why trlAudioElement (fed the
+  // untouched original stream, never boosted) exists as a separate decoy to
+  // keep the real stats alive.
+  // Builds the boost graph AND taps its own level with an AnalyserNode, so
+  // duck detection reads the exact signal being played instead of asking
+  // WebRTC getStats() about a track this same graph is also tapping (which
+  // appears to break that track's own stats reporting in Chrome, regardless
+  // of whether another element also renders the untouched original).
+  _boostTrlGain = (stream) => {
+    this._closeTrlGainContext();
+    try {
+      const AudioCtx = window.AudioContext || window.webkitAudioContext;
+      const ctx = new AudioCtx();
+      const source = ctx.createMediaStreamSource(stream);
+      const lowcut = ctx.createBiquadFilter();
+      lowcut.type = "highpass";
+      lowcut.frequency.value = TRL_LOWCUT_HZ;
+      const gainNode = ctx.createGain();
+      gainNode.gain.value = dbToGain(TRL_GAIN_DB);
+      // element.volume * gain can exceed 1.0 and hard-clip at the output
+      // ceiling. Threshold sits close to true digital max (unlike the -3dB
+      // attempt earlier, which squashed almost the entire boost) so it only
+      // catches genuine peaks instead of eating the gain increase itself.
+      const limiter = ctx.createDynamicsCompressor();
+      limiter.threshold.value = -1;
+      limiter.knee.value = 0;
+      limiter.ratio.value = 12;
+      limiter.attack.value = 0.003;
+      limiter.release.value = 0.15;
+      const analyser = ctx.createAnalyser();
+      analyser.fftSize = 512;
+      const dest = ctx.createMediaStreamDestination();
+      source.connect(lowcut).connect(gainNode).connect(limiter).connect(analyser).connect(dest);
+      this.trlGainContext = ctx;
+      this.trlGainNode = gainNode;
+      this.trlAnalyser = analyser;
+      this.trlAnalyserBuffer = new Uint8Array(analyser.fftSize);
+      // If the context starts suspended (autoplay policy), the graph processes
+      // nothing at all - dest.stream carries silence regardless of element.muted.
+      if (ctx.state === "suspended") {
+        const p = ctx.resume();
+        if (p && typeof p.catch === "function") {
+          p.catch((err) => log.debug("[shidur] trl gain context resume failed:", err && err.message));
+        }
+      }
+      return dest.stream;
+    } catch (err) {
+      log.debug("[shidur] trl gain boost failed, using raw stream:", err && err.message);
+      return stream;
+    }
+  };
+
+  // RMS level (0..1ish) of the actual boosted signal, read straight from the
+  // analyser tapped into the boost graph. Synchronous - no getStats() round trip.
+  _getTrlBoostLevel = () => {
+    if (!this.trlAnalyser || !this.trlAnalyserBuffer) return 0;
+    this.trlAnalyser.getByteTimeDomainData(this.trlAnalyserBuffer);
+    let sumSquares = 0;
+    for (let i = 0; i < this.trlAnalyserBuffer.length; i++) {
+      const normalized = (this.trlAnalyserBuffer[i] - 128) / 128;
+      sumSquares += normalized * normalized;
+    }
+    return Math.sqrt(sumSquares / this.trlAnalyserBuffer.length);
+  };
+
+  _closeTrlGainContext = () => {
+    if (!this.trlGainContext) return;
+    const ctx = this.trlGainContext;
+    this.trlGainContext = null;
+    this.trlGainNode = null;
+    this.trlAnalyser = null;
+    this.trlAnalyserBuffer = null;
+    try {
+      const p = ctx.close();
+      if (p && typeof p.catch === "function") {
+        p.catch((err) => log.debug("[shidur] trl gain context close failed:", err && err.message));
+      }
+    } catch (err) {
+      log.debug("[shidur] trl gain context close threw:", err && err.message);
+    }
+  };
+
   destroy() {
     this.clean();
     if (this.janus) {
@@ -395,8 +519,8 @@ class JanusStream {
     if (talk) {
       this.mixvolume = this.audioElement.volume;
       this.talking = true;
-      this.trlAudioElement.volume = this.mixvolume;
-      this.trlAudioElement.muted = false;
+      this.trlBoostElement.volume = this.mixvolume;
+      this.trlBoostElement.muted = false;
 
       this.prevAudioVolume = this.audioElement.volume;
       this.prevMuted = this.audioElement.muted;
@@ -427,7 +551,7 @@ class JanusStream {
       log.debug("[shidur] get stream back id: ", localStorage.getItem("vrt_lang"), id);
       this._safeSwitch(this.audioJanusStream, id, "audio");
       log.debug("[shidur] Switch audio stream back");
-      this.trlAudioElement.muted = true;
+      this.trlBoostElement.muted = true;
       this.talking = null;
       this.mixvolume = null;
     }
@@ -437,34 +561,30 @@ class JanusStream {
   };
 
   ducerMixaudio = () => {
-    if (this.trlAudioJanusStream) {
-      // Get remote volume of translator stream (FYI in case of Hebrew, this will be 0 - no translation).
-      this.trlAudioJanusStream.getVolume(null, (volume) => {
-        log.trace("[shidur] ducer volume level: ", volume);
-        if (volume === -1) {
-          if (this.talking) {
-            clearInterval(this.talking);
-            return;
-          }
-        }
-        if (this.prevAudioVolume !== this.audioElement.volume || this.prevMuted !== this.audioElement.muted) {
-          // This happens only when user changes audio, update mixvolume.
-          this.mixvolume = this.audioElement.muted ? 0 : this.audioElement.volume;
-          this.trlAudioElement.volume = this.mixvolume;
-        }
-        if (volume > 0.05) {
-          // If translator is talking (remote volume > 0.05) we want to reduce Rav to 5%.
-          this.audioElement.volume = this.mixvolume * 0.05;
-        } else if (this.audioElement.volume + 0.01 <= this.mixvolume) {
-          // If translator is not talking or no translation (Hebrew) we want to slowly raise
-          // sound levels of original source up to original this.mixvolume.
-          this.audioElement.volume = this.audioElement.volume + 0.01;
-        }
-        // Store volume and mute values to be able to detect user volume change.
-        this.prevAudioVolume = this.audioElement.volume;
-        this.prevMuted = this.audioElement.muted;
-      });
+    if (!this.trlAnalyser) return;
+    // RMS level of the actual boosted/audible signal, read synchronously from
+    // the analyser tapped into the boost graph - see _boostTrlGain/_getTrlBoostLevel.
+    const volume = this._getTrlBoostLevel();
+    log.trace("[shidur] ducer volume level: ", volume);
+    if (this.prevAudioVolume !== this.audioElement.volume || this.prevMuted !== this.audioElement.muted) {
+      // This happens only when user changes audio, update mixvolume.
+      this.mixvolume = this.audioElement.muted ? 0 : this.audioElement.volume;
+      this.trlBoostElement.volume = this.mixvolume;
     }
+    if (volume > 0.02) {
+      // If translator is talking we want to reduce Rav to 5%.
+      // NOTE: this threshold is against an AnalyserNode RMS reading (0..1ish),
+      // a different scale than the old getStats()-based audioLevel - needs its
+      // own live calibration, starting point only.
+      this.audioElement.volume = this.mixvolume * 0.05;
+    } else if (this.audioElement.volume + 0.01 <= this.mixvolume) {
+      // If translator is not talking or no translation (Hebrew) we want to slowly raise
+      // sound levels of original source up to original this.mixvolume.
+      this.audioElement.volume = this.audioElement.volume + 0.01;
+    }
+    // Store volume and mute values to be able to detect user volume change.
+    this.prevAudioVolume = this.audioElement.volume;
+    this.prevMuted = this.audioElement.muted;
   };
 
   setVideo = (videos) => {
@@ -538,6 +658,16 @@ class JanusStream {
         this.reattachMediaStream(next, prev);
       } else if (this.trlAudioMediaStream) {
         this.attachMediaStream(next, this.trlAudioMediaStream);
+      }
+    }
+  }
+
+  attachTrlBoostStream_(next, prev) {
+    if (next) {
+      if (prev && next !== prev) {
+        this.reattachMediaStream(next, prev);
+      } else if (this.trlBoostMediaStream) {
+        this.attachMediaStream(next, this.trlBoostMediaStream);
       }
     }
   }


### PR DESCRIPTION
During a Talk event (live Q&A), the client mixes two raw streams itself (mix-minus + translator) instead of the normal BSS-premixed feed, and is supposed to duck the mix-minus under the translator while they speak. This wasn't working, and the translator was also noticeably quieter than normal since it comes straight from Janus without BSS leveling.

Root causes:
- Duck threshold (0.05) was calibrated for a different volume-metering scheme and was above what real speech ever produced on this getStats() based meter, so the duck condition essentially never fired.
- getVolume() picked whichever audio-kind stat entry came last from getStats(), which could be a non-inbound-rtp entry with no real level, silently overwriting a correct reading.
- Boosting the translator's gain (needed since it arrives quieter than normal) by tapping its stream/element via Web Audio breaks that same track's getStats() energy reporting in Chrome - so gain-boosting and duck-detection-via-getStats() were fundamentally incompatible.

Fixes:
- getVolume() now specifically reads the inbound-rtp stat entry.
- Split translator playback into two elements: trlAudioElement, a permanently-muted decoy that keeps the raw track alive for any legacy consumer, and trlBoostElement, the actually-audible element playing a separately gain-boosted (+10dB), low-cut (100Hz+ highpass), limited copy built in a dedicated Web Audio graph.
- Duck detection now reads an AnalyserNode tapped into that same boost graph instead of asking WebRTC getStats() about a track the graph is also tapping - this measures exactly what's audible, with no getStats()/gain-boost conflict, and needed its own threshold calibration against the new 0..1 RMS scale.